### PR TITLE
Now we shouldn't get 5 separate amlicites approaching messages

### DIFF
--- a/src/battle.py
+++ b/src/battle.py
@@ -174,8 +174,11 @@ class Battle(object):
 
     def set_start_dialog(self):
         script = ''
+        last_enemy_name = ''
         for enemy in self.enemies:
-            script += '{} approaching.\n'.format(enemy.name.title())
+            if enemy.name != last_enemy_name:
+                script += '{} approaching.\n'.format(enemy.name.title())
+                last_enemy_name = enemy.name
         self.left_dialog = create_prompt(script, silent=True)
 
     def set_bar_color(self):


### PR DESCRIPTION
This is just a fix for something that felt annoying to me.  The way I fixed it seems just a little bit hacky though.  I thought having some Enemy property that differentiates between named guys and generic guys might be cleaner.  Check that property and print the approaching message accordingly.  But this works just as well, I guess.