### PR TITLE
Added compatibility with Wayland/Sway.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,15 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pygame = "==2.0.1"
-pyscroll = "==2.19.2"
-PyTMX = "==3.21.7"
-PyInstaller = "==4.1"
-future = "==0.18.2"
-pywin32-ctypes = "==0.2.0"
-macholib = "==1.14"
+pygame = "==2.4.0"
+pyscroll = "==2.29.0"
+PyTMX = "==3.31.0"
+PyInstaller = "==5.13.0"
+future = "==0.18.3"
+pywin32-ctypes = "==0.2.2"
+macholib = "==1.16.2"
 
 [dev-packages]
 
 [requires]
-python_version = "3.8.5"
+python_version = "3.11.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "782622e35bdf06191c440bb3a56f4222b8aa2ad3f0f584cfe26b8107d384f29b"
+            "sha256": "6d604e13ad3cd3ce1e362e5162ce407c97e2853ac03a336b320ff06a1c9139e6"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8.5"
+            "python_version": "3.11.3"
         },
         "sources": [
             {
@@ -25,126 +25,150 @@
         },
         "future": {
             "hashes": [
-                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+                "sha256:34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307"
             ],
             "index": "pypi",
-            "version": "==0.18.2"
+            "version": "==0.18.3"
         },
         "macholib": {
             "hashes": [
-                "sha256:0c436bc847e7b1d9bda0560351bf76d7caf930fb585a828d13608839ef42c432",
-                "sha256:c500f02867515e6c60a27875b408920d18332ddf96b4035ef03beddd782d4281"
+                "sha256:44c40f2cd7d6726af8fa6fe22549178d3a4dfecc35a9cd15ea916d9c83a688e0",
+                "sha256:557bbfa1bb255c20e9abafe7ed6cd8046b48d9525db2f9b77d3122a63a2a8bf8"
             ],
             "index": "pypi",
-            "version": "==1.14"
-        },
-        "pefile": {
-            "hashes": [
-                "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc",
-                "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==2023.2.7"
+            "version": "==1.16.2"
         },
         "pygame": {
             "hashes": [
-                "sha256:0571dde0277483f5060c8ee43cbfd8df5776b12505e3948eee241c8ce9b93371",
-                "sha256:07ed57062be4bb9741f57dab1751d95574c091c9958ed7e39cdb246d50903283",
-                "sha256:107d5f82f471baee4b9522a691cb320dd52dbf329ed7a0e9ab25f75cd3caf890",
-                "sha256:10ca736eecedadf492ba1191f9fa3a5e6f30db2b9f8882b3ee7706d5a89c14e0",
-                "sha256:19357c826ab94f9ae5b4ec5cb752cc806cfc29ea32cf7bdaacb65fa2615607e8",
-                "sha256:21475405bcdeb20b8a796a3da6704ebb816e06b29749dd64ff619e80816b7932",
-                "sha256:2d9b0a66034fed390ee367a549435853502c9d4fe82ac0fa3a520f0ad5648e6e",
-                "sha256:30eb5c7adb0b3362024cec2c461be6978fbfc99c3bca974e438b1b540cd09438",
-                "sha256:3270cbcff40ca2b5622a145346298a33285c91b6d50097e0b85123d9a2bc7c9b",
-                "sha256:328d70d40bc9a6defb9f330f5e7f3d0726af1e7c2308ebca582e69480db2950d",
-                "sha256:3b31d088129977885f72037c55cfa1140e9bcf3468e68b46141f6cc2b33d456b",
-                "sha256:3c2676b4fd278d632037eacd3b0524ce1a592c048e8e5eb5830475f83585cb3a",
-                "sha256:44f3ff8224d7cb998642400371c685005c8316b55e87794cbf1f6407b88ec424",
-                "sha256:49c2f58559c1fbf4ba258e4b141578ccb0e83da3d4f823894f6171a8f0d594ed",
-                "sha256:4d3135a1f8c76c3fff1ef8b7a51e4c6523748e9bdbd7bca6daa69790ce0e798a",
-                "sha256:4f41252dfa1e8bb95f2ea51fba710827dde9820a535623d002a65621bafe7e3f",
-                "sha256:5aeeb6659a7fe7760a78e449566553ae8c949ae29dd907a8eb4171fa0a274c16",
-                "sha256:5afc34f0af0cec09a20b6bb09090054fac5169ab01909e01b06e7e0752ab0153",
-                "sha256:5f057e5aa4c383fcf18560dcae2c5593e37e3fc941083a0a00a17f7cf25ee522",
-                "sha256:72625dc949c6d08ba7ce7c37a33163bb498d90ca0d7e626db3cfbf486df4db1d",
-                "sha256:7ea518d8eeb072c77c16977cdee3c59d9fffa750ed9c7c9c533ba520b6b08af7",
-                "sha256:81510ffb1c31a3827c6be047b1926d81caf36dc734564ca0e14903d6bce60c6f",
-                "sha256:845385caf99f8d941607791c60e560d24b4a35c70eef0b01c30cfde0b913ff92",
-                "sha256:898874521a9be1f9dbc5b036a9755803287c2664e335afd3e10963f7f4ccb853",
-                "sha256:8b1e7b63f47aafcdd8849933b206778747ef1802bd3d526aca45ed77141e4001",
-                "sha256:9aead3f2eed90260136b201f398965900c5335c974bb7b47c381d98e39284018",
-                "sha256:9de559462aaa68c40bb7625dcd587584b4eb85c4208528dc97b9ee7254945294",
-                "sha256:9f48277de1daa83fd58a722b2e3423201b5eb39842227f32702fb78e4bba5a71",
-                "sha256:9fd0691c4fe58b932674bb6a91d2808790e8269c3183ef16052f13e1c602ac00",
-                "sha256:a4e35d89b6754941e82df1ce980a1c370943d3c076938d94ed1e48165dd6a11b",
-                "sha256:ad230911d61f448c09886d3c92b2eae44ca7530babe9c48e74e02a0622ce2d34",
-                "sha256:b812285d23b5644c643a6ae30553a772f935f47f61826660b108b8727936384b",
-                "sha256:bf833c853a0568738ee5d88e1345c17bf3e8db626c36fb895327a35bb1827b0b",
-                "sha256:c188ce4bf1544f2758e8b651f4349a0f3dc441e09d8ab7c4863db1ae8f084a32",
-                "sha256:d8059084ce54b2c3d7b2c8bacd5f6490db849b2d2d6e7368c160b08504c87e73",
-                "sha256:e72cdc97a49509ca2298350c2c3a0ac26bc8e943ce003a7d245df42e91439d5d",
-                "sha256:eab18df58dcc8512f1b694f7218146828d7e3dd3f4e73bfd6942a11810293fd5",
-                "sha256:ece424c83a575c2e0ba25815871458d3bbade46d76b7997236fb51a0251229ab",
-                "sha256:ed80b40da839d60f4c03915bb3638e3c96ea8c30e689d0cc309b7597d82cc217",
-                "sha256:fd5ee0f42d59a290c049f91894e0739f62c2908e7edc028ffb847a105e68bfc3",
-                "sha256:fd6acd09d2a0fd3f616b18f977f399ed3dd95e2d6754f115837f026d19d62e10"
+                "sha256:00ecd4688ee25d5d4cf48eddab18749a9bb2b382772f7fa8a987e4d21026c603",
+                "sha256:075c1282b1d307669c8ef29942564b91acb85623bedba3bfb841079d539ded31",
+                "sha256:13511c7c29f0fc23636f3b95a96ab45f964e84073e7e27dc602a479cd274d89a",
+                "sha256:1422673a2b485153cbc20dbbd37af791c9842ca98a1b7a89fe3ac115cce79805",
+                "sha256:14492d8c0eaad778bb10b6d53eaea4ef77f4d3431b6b7c857397dc6cf4397ac9",
+                "sha256:1b7201a44869eb420dd56c8e003251c9e7422c5304b3e78508e767a5634ab31b",
+                "sha256:23543e2d206d8de7d6db4f7b1c74e6fea6c01ead63caf7252e63341e1cdb09f6",
+                "sha256:2946c151691c80ffb9f3f39e1f294d7ed9edaae1814e528d2f5b4751e7e6d903",
+                "sha256:32ed4d4317bce8fe78592a7b5b4a07f2e0ff814e35c66cb5a3b398dae96c3f27",
+                "sha256:3ab14e06c302921f33d25180813711a920acef386d3992fc21731d2d5e8e86f0",
+                "sha256:418659c2d42f6a2356e2691006d79b6e07fd4992f9e904a2638c51c992f3e41b",
+                "sha256:43db3a6c9be3d94eececf7c86cde7584d2bb87f394ade40139c3b4e528fdff24",
+                "sha256:47be83060a9dbc79763fd230f04d53a29064b5f64d1b59425c432d3570b22623",
+                "sha256:47fd096ceb68d966681f8d0e820f7305bf05b30421ca562cfdb3c89a5aef26e5",
+                "sha256:4a98ed8c47e367b9233b5ca25c36c2b45ab61959ac543195f0b6349f0a599ec8",
+                "sha256:4b562cfdd8caa76ba47ca2a9211fee6b0a95ceb95c9da94cf60a3909b2300854",
+                "sha256:4ffec9661731fb674ccc88d1de92709219047af3d8198d0e6203c21f3f1b54a7",
+                "sha256:5210cb09ec31281e16fda008bf8dfe2e024eef58e075dd0c01935d0004fdfffd",
+                "sha256:53bfdc1aea619fa8d347be37b08de87089d543375948aacf8b163b0c5eb6d4e4",
+                "sha256:5a2aee4214e5efed2cb3650139010dd4d0b1c29a9760278ab259d0b46281b66a",
+                "sha256:5a93d368311d40827dc5f0cad2a0e9a8700c1b017346808cfdfd9ea98aee45df",
+                "sha256:6060d68d10fafd51c4cb3a7d687d741009881860dfd429c863e570877e2ce9de",
+                "sha256:627c8bb007a757da18d32c5d9b7ac50ab0356d9e922d570b0572765778080787",
+                "sha256:63591f381e5b28b90e115ac7a96f8ce5ecb917facb42d79d4f89714f89cc6d8e",
+                "sha256:65ee75e0e83e393fdc5c06e55e376c7511881a5ebee006ecca89cb1b3b41d6f1",
+                "sha256:6ba967d0e3fed8611f1face6695dc8fa554ee543d300681f8080f5de9cc7da73",
+                "sha256:6c0081546749c0b4341ce575622a4f8eee05f675d3a0872ab6aed6e5bd2ba5a8",
+                "sha256:6ec870a63295ebff737640c4ef39868312e206dcba655b4ad5c7d0e8c2488b73",
+                "sha256:751bc57e4c3b7cd92762344562dcbd405e2b54488de1d7a1e083a470bdbc5ae9",
+                "sha256:75ef535ebe541b74a160bb59c3e520f543250d19f69d5973350ec1b9706e1469",
+                "sha256:79b0962a8f09788ca735532cfcf2dd053424fe5eabbda564b74f8e5e2eb11f48",
+                "sha256:7e5d32def075e495b4802371fd8cda96ff4957aa39e215f83d87022dedf14cfb",
+                "sha256:7fa1e65fd559823997f39a592cb49d8c89dd31c8bbde8273fe3922e2c1f294f6",
+                "sha256:802b03f6c367359c94eb6a90169666efa1aa1d6e24fce37a0b21642ccdfe48cf",
+                "sha256:80502eb26483b0206d0508475ec7d67a86bc0afc5bb4aad3a6172a7a85a27554",
+                "sha256:867cf19f1c7aa6f187a0a31b702f5668e935e700b46d94bd58e94ec8581cf081",
+                "sha256:8b6e1493724d29e46a0e7e8125d9808c9957c652db67afe9497d385509fc5ac5",
+                "sha256:8f97c8be81b3262ad8dae982485c4a73c9f2374614dfc0db8eb0f754badb29d6",
+                "sha256:93bb1406125ae9bd7a9bb0d45f11b30f157ea8d2efee1ebe9d781b1d1a9fce6b",
+                "sha256:99c296ecb8ce6ea1f404f4d174fdb215c64515827778525301c29ddf6f8e6e07",
+                "sha256:9f6b7a604812f447495829751dfe7ab57cb31c2c9acdb07ba4b7157490411a12",
+                "sha256:a66b314f4a637784d5ca2970745bb2e6e554447dce8f4cfedd9b9fcef5e3ffc6",
+                "sha256:ab8115af26a9e95f39b08fff416f097803480f265500b218a5ca065d6e73124f",
+                "sha256:b04451e5addae3a078a7a4f494e6b217025f4813dfb364a49c250fc5dfd1d2e2",
+                "sha256:b4c75dd345707da622c78dbd6a63a025f7b89377ddc4e71ba40043929824f5d4",
+                "sha256:b6b94fc99487ce4a45ce00fa9145f4861f6e021254a005101d00bc17a4bb4f5c",
+                "sha256:bb5a39320d00fa781959d2d0151e6f0293dd1398c6dc9dc934112ecce7b4fb52",
+                "sha256:be7f948d33d0536c2922289e6f5983251cb0bd0d727db6ff692886c239f47a2c",
+                "sha256:c09323eeae9e0cb2ced0cb3635485ae17f4f1b2b6b908a494ce2d830c609d4be",
+                "sha256:c4241e1da3852a955d37a22157ed51b2d30a65f7987eac9d162bb302fb754d87",
+                "sha256:ca2ecc65126eaaa5b8e6a119913cfb2c2b1ed4c8ee1b980baf333aa9d379f227",
+                "sha256:cad74cbbefbdb81cb22a9ea22561614b8dc58fcd52cd54126bbb8ee9ee77a5d5",
+                "sha256:cff815181437add5f3d702e8c7f1d2aa4ed04ed04cde27ec809e7ac516ee6b5f",
+                "sha256:d9b1127f085d09c7c0a976d440e8fc2f7adc579d62abcfc20c23c2699bbe2dc1",
+                "sha256:de963a4b8787d93a9fba8f4052d9dde8b12adbeac5781e48035be1557dfadb20",
+                "sha256:e2a3176b33b97ebae397f951d254e3155a0afe730e1b76fb35126555c27dd3b5",
+                "sha256:e3603e70e96ee30af1954ce57d4922a059402f368013e7138e90f1c03d185267",
+                "sha256:e5f043751840a07ff0160abe46ed42a88bc29baee93656abb5a050beda176306",
+                "sha256:e70fd71e0321a805001192e08ae4af45b86c68f155670230c3f6f4dd25089e70",
+                "sha256:e75d8c2980d719045be366160568bf508cbbed21285efe32468c75abcd4cf8b3",
+                "sha256:ef14750fa60b47510cfe9c7c37e7abe67617f5d1f1a8ffa257a59d49836dadda",
+                "sha256:f3020fb98f27a6ea79418a5b332ca07be93884e4a455c8a0a31b2dcf39ee2d96",
+                "sha256:f576403c2b14f0eea694365b9018d5bacac70b1550261ffc7a54a92e18967541",
+                "sha256:f9c8bb7b77f97eb49dac900445fbf96a332d2072588949d6396581933843fb04",
+                "sha256:fa2531f83e7c5f6f7cc20a1b4e0f982bd608aad81ff6c385148e64256ab0419f",
+                "sha256:faa3b63b71d555e7a21cecc11c65e059d9cb1902158d863ac3592e1947bc521a",
+                "sha256:fb7bb86c4aedb4382d7f643ff7d21ab4731d59ddb9b448e78b9125ab1addc007",
+                "sha256:fbcba1b06f42338fecbd366227025f81729d9f4a577677fd3cd1ceff34d7286a"
             ],
             "index": "pypi",
-            "version": "==2.0.1"
+            "version": "==2.4.0"
         },
         "pyinstaller": {
             "hashes": [
-                "sha256:954ae81de9a4bc096ff02433b3e245b9272fe53f27cac319e71fe7540952bd3d"
+                "sha256:0df43697c4914285ecd333be968d2cd042ab9b2670124879ee87931d2344eaf5",
+                "sha256:1fde4381155f21d6354dc450dcaa338cd8a40aaacf6bd22b987b0f3e1f96f3ee",
+                "sha256:24009eba63cfdbcde6d2634e9c87f545eb67249ddf3b514e0cd3b2cdaa595828",
+                "sha256:28d9742c37e9fb518444b12f8c8ab3cb4ba212d752693c34475c08009aa21ccf",
+                "sha256:2d03419904d1c25c8968b0ad21da0e0f33d8d65716e29481b5bd83f7f342b0c5",
+                "sha256:3a331951f9744bc2379ea5d65d36f3c828eaefe2785f15039592cdc08560b262",
+                "sha256:5e446df41255e815017d96318e39f65a3eb807e74a796c7e7ff7f13b6366a2e9",
+                "sha256:78975043edeb628e23a73fb3ef0a273cda50e765f1716f75212ea3e91b09dede",
+                "sha256:7fdd319828de679f9c5e381eff998ee9b4164bf4457e7fca56946701cf002c3f",
+                "sha256:9fc27c5a853b14a90d39c252707673c7a0efec921cd817169aff3af0fca8c127",
+                "sha256:cd7d5c06f2847195a23d72ede17c60857d6f495d6f0727dc6c9bc1235f2eb79c",
+                "sha256:e5fb17de6c325d3b2b4ceaeb55130ad7100a79096490e4c5b890224406fa42f4"
             ],
             "index": "pypi",
-            "version": "==4.1"
+            "version": "==5.13.0"
         },
         "pyinstaller-hooks-contrib": {
             "hashes": [
-                "sha256:ab56c192e7cd4472ff6b840cda4fc42bceccc7fb4234f064fc834a3248c0afdd",
-                "sha256:d2ea40a7105651aa525bfe5fe309aa264d4d9bb49f839b862243dcf0a56c34cd"
+                "sha256:cca6cdc31e739954b5bbbf05ef3f71fe448e9cdacad3a2197243bcf99bea2c00",
+                "sha256:e60185332a6b56691f471d364e9e9405b03091ca27c96e0dbebdedb7624457fd"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2023.1"
+            "version": "==2023.5"
         },
         "pyscroll": {
             "hashes": [
-                "sha256:031d0123989eceabf5b7047c0074a0da9ab379c8534ac7ead8a3dbea731aad9c"
+                "sha256:211c01607fd066eb13c30366c599d47fe5edfc354198604a516a09166c2e31a6",
+                "sha256:5adb123c8e0df1c3e7b0fddccfa20e0953b677b86afca4452dbe9110690b6006"
             ],
             "index": "pypi",
-            "version": "==2.19.2"
+            "version": "==2.29.0"
         },
         "pytmx": {
             "hashes": [
-                "sha256:f6e9c1faaf689cea5a568eed06edf0b811b192c8b71bb5ec9d22fe3f61938fa7"
+                "sha256:8d572fa8889236879e19351f99f425a0df905105f8503d77470746c386befd05",
+                "sha256:ead258771640c82029c6fef53661464163e791e729b7e63def53e1bd85e4efe8"
             ],
             "index": "pypi",
-            "version": "==3.21.7"
+            "version": "==3.31.0"
         },
         "pywin32-ctypes": {
             "hashes": [
-                "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942",
-                "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"
+                "sha256:3426e063bdd5fd4df74a14fa3cf80a0b42845a87e1d1e81f6549f9daec593a60",
+                "sha256:bf490a1a709baf35d688fe0ecf980ed4de11d2b3e37b51e5442587a75d9957e7"
             ],
             "index": "pypi",
-            "version": "==0.2.0"
+            "version": "==0.2.2"
         },
         "setuptools": {
             "hashes": [
-                "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a",
-                "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"
+                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
+                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.6.1"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==1.16.0"
+            "version": "==68.0.0"
         }
     },
     "develop": {}

--- a/src/rotj.py
+++ b/src/rotj.py
@@ -39,6 +39,21 @@ if __name__ == '__main__':
     info_object = pygame.display.Info()
     os.environ['SDL_VIDEO_WINDOW_POS'] = "{},{}".format(int(.1*info_object.current_w), int(.1*info_object.current_h))
     screen = pygame.display.set_mode((int(.8*info_object.current_w), int(.8*info_object.current_h)))
+    # In Sway we have wait and see what size the window really is (otherwise the
+    # game doesn't draw)
+    if 'SWAYSOCK' in os.environ:
+        swaymsg_output = os.popen(
+            # I would expect a race condition, but both of these seem to always 
+            # work. Testing for focused is slightly better in the case that 
+            # someone is playing several pygames at once
+            #'swaymsg -rt get_tree | grep -B 12 pygame | grep -A 4 window_rect'
+            '''swaymsg -rt get_tree | grep -A 20 '"focused": true' | grep -A'''
+                + '''4 window_rect'''
+        ).read().split('\n')[3:5]
+        sway_window_size = [
+            int(line.split(':')[1].strip(' ,')) for line in swaymsg_output
+        ]
+        screen = pygame.display.set_mode((*sway_window_size,))
     pygame.mixer.init(frequency=44100)
     try:
         game = Game(screen, args)

--- a/src/text.py
+++ b/src/text.py
@@ -340,6 +340,9 @@ class TextBox(object):
 
     def shutdown(self):
         if not self.silent:
+            # I don't see why we need to call init() again, but otherwise pygame
+            # barfs errors
+            pygame.mixer.init()
             self.typing_sound.stop()
 
     def handle_input(self, pressed):


### PR DESCRIPTION
Bumped the version of all dependencies:
* python 3.8.5 -> 3.11.3
* pygame 2.0.1 -> 2.4.0
* pyscroll 2.19.2 -> 2.29.0
* PyTMX 3.21.7 -> 3.31.0
* PyInstaller 4.1 -> 5.13.0
* future 0.18.2 -> 0.18.3
* pywin32-ctypes 0.2.0 -> 0.2.0
* macholib 1.14 -> 1.16.2

The old version of pygame/SDL did not support Wayland correctly, but it was enough to bump all the packages to fairly recent versions. Due to bug with pygame/SDL, the attributes needed to make Wayland consider the pygame window nonresizable (WindowMaxsize and WindowMinsize with equal values) are not correctly set, leading to issues in Sway. The current workaround is to use swaymsg to get the correct size of the window and reset the pygame display to match, though this sort of finicky.

Also, for reasons not clear to me, the mixer has to be reinitialize to prevent some errors relating to textboxes.

I can't easily test on Windows/MacOS, but I confirmed that the rotj.py runs correctly on Linux 5.19.3-arch1-1 in both X11 and Wayland.